### PR TITLE
Move reset, contrast, bias and extended commands to functions

### DIFF
--- a/Adafruit_Nokia_LCD/PCD8544.py
+++ b/Adafruit_Nokia_LCD/PCD8544.py
@@ -60,6 +60,11 @@ class PCD8544(object):
 			self._gpio = GPIO.get_platform_gpio()
 		if self._rst is not None:
 			self._gpio.setup(self._rst, GPIO.OUT)
+		# Default to bit bang SPI.
+		if self._spi is None:
+			self._spi = SPI.BitBang(self._gpio, self._sclk, self._din, None, self._cs)
+		# Set pin outputs.
+		self._gpio.setup(self._dc, GPIO.OUT)
 		# Initialize buffer to Adafruit logo.
 		self._buffer = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 						0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -117,11 +122,6 @@ class PCD8544(object):
 
 	def begin(self, contrast=40, bias=4):
 		"""Initialize display."""
-		# Default to bit bang SPI.
-		if self._spi is None:
-			self._spi = SPI.BitBang(self._gpio, self._sclk, self._din, None, self._cs)
-		# Set pin outputs.
-		self._gpio.setup(self._dc, GPIO.OUT)
 		self.reset()
 		# Set LCD bias.
 		self.set_bias(bias)


### PR DESCRIPTION
In order to support using the same SPI bus for 3 displays or more and multiplexing the CE I need to reset all the displays but then send set up commands to each display in turn. So I have split things up a bit.

This does not change the default functionality but splits out the set up commands into their own functions.
- Fixed typo in the set_contrast command.
- Created a set_bias command.
- Created a extended_command function.
- Created a reset function.
- Moved the setup of the IO pins to the init function.
- Changed the begin to use new functions.
