### PR TITLE
Change the examples to import Image modules form the module PIL, for Pillow interoperability

### DIFF
--- a/examples/animate.py
+++ b/examples/animate.py
@@ -25,9 +25,9 @@ import time
 import Adafruit_Nokia_LCD as LCD
 import Adafruit_GPIO.SPI as SPI
 
-import Image
-import ImageFont
-import ImageDraw
+from PIL import Image
+from PIL import ImageFont
+from PIL import ImageDraw
 
 
 # Raspberry Pi hardware SPI config:

--- a/examples/image.py
+++ b/examples/image.py
@@ -24,7 +24,7 @@ import time
 import Adafruit_Nokia_LCD as LCD
 import Adafruit_GPIO.SPI as SPI
 
-import Image
+from PIL import Image
 
 
 # Raspberry Pi hardware SPI config:

--- a/examples/shapes.py
+++ b/examples/shapes.py
@@ -24,9 +24,9 @@ import time
 import Adafruit_Nokia_LCD as LCD
 import Adafruit_GPIO.SPI as SPI
 
-import Image
-import ImageDraw
-import ImageFont
+from PIL import Image
+from PIL import ImageDraw
+from PIL import ImageFont
 
 
 # Raspberry Pi hardware SPI config:


### PR DESCRIPTION
Hi! This way you can use the PIL compatible library [Pillow](http://pillow.readthedocs.org/about.html).
