### PR TITLE
ImportError when the library is installed

### DIFF
--- a/Adafruit_Nokia_LCD/__init__.py
+++ b/Adafruit_Nokia_LCD/__init__.py
@@ -1,1 +1,1 @@
-from PCD8544 import *
+from .PCD8544 import *


### PR DESCRIPTION
When installing the library using

```
python setup.py install

>>> import Adafruit_Nokia_LCD as LCD
[...]
    File "__init__.py", line 1 in <module>
ImportError: No module named 'PCD8544'
```

The module PCD8544 cannot be found because it is part of package Adafruit_Nokia_LCD. The import line in file **init**.py should use the following relative import

```
from .PCD8544 import *
```

as proposed in this PR.
