### PR TITLE
Multiply sequence by float in Python3 or future division

### DIFF
--- a/Adafruit_Nokia_LCD/PCD8544.py
+++ b/Adafruit_Nokia_LCD/PCD8544.py
@@ -169,7 +169,7 @@ class PCD8544(object):
 
 	def clear(self):
 		"""Clear contents of image buffer."""
-		self._buffer = [0] * (LCDWIDTH * LCDHEIGHT / 8)
+		self._buffer = [0] * int(LCDWIDTH * LCDHEIGHT / 8)
 
 	def set_contrast(self, contrast):
 		"""Set contrast to specified value (should be 0-127)."""


### PR DESCRIPTION
In Python3 or when `from future import division` is used the division returns a float and thus create a TypeError for mutiplying a sequence by a float. This patch forces the float to int conversion.
