### PR TITLE
use board pin numbering for compatibility with orangepi and nanopi

### DIFF
--- a/Adafruit_Nokia_LCD/PCD8544.py
+++ b/Adafruit_Nokia_LCD/PCD8544.py
@@ -57,7 +57,7 @@ class PCD8544(object):
 		self._spi = spi
 		# Default to detecting platform GPIO.
 		if self._gpio is None:
-			self._gpio = GPIO.get_platform_gpio()
+			self._gpio = GPIO.get_platform_gpio(mode='board')
 		if self._rst is not None:
 			self._gpio.setup(self._rst, GPIO.OUT)
 		# Default to bit bang SPI.

--- a/examples/animate.py
+++ b/examples/animate.py
@@ -31,10 +31,17 @@ from PIL import ImageDraw
 
 
 # Raspberry Pi hardware SPI config:
-DC = 23
-RST = 24
-SPI_PORT = 0
+DC = 22
+RST = 18
+SPI_PORT = 0 # 1 for OrangePI
 SPI_DEVICE = 0
+
+# Raspberry Pi software SPI config:
+SCLK =23
+DIN = 19
+# DC = 22
+# RST = 18
+CS = 24
 
 # Beaglebone Black hardware SPI config:
 # DC = 'P9_15'

--- a/examples/image.py
+++ b/examples/image.py
@@ -28,10 +28,17 @@ from PIL import Image
 
 
 # Raspberry Pi hardware SPI config:
-DC = 23
-RST = 24
-SPI_PORT = 0
+DC = 22
+RST = 18
+SPI_PORT = 0 # 1 for OrangePI
 SPI_DEVICE = 0
+
+# Raspberry Pi software SPI config:
+SCLK =23
+DIN = 19
+# DC = 22
+# RST = 18
+CS = 24
 
 # Raspberry Pi software SPI config:
 # SCLK = 4

--- a/examples/shapes.py
+++ b/examples/shapes.py
@@ -30,17 +30,17 @@ from PIL import ImageFont
 
 
 # Raspberry Pi hardware SPI config:
-DC = 23
-RST = 24
-SPI_PORT = 0
+DC = 22
+RST = 18
+SPI_PORT = 0 # 1 for OrangePI
 SPI_DEVICE = 0
 
 # Raspberry Pi software SPI config:
-# SCLK = 4
-# DIN = 17
-# DC = 23
-# RST = 24
-# CS = 8
+SCLK =23
+DIN = 19
+# DC = 22
+# RST = 18
+CS = 24
 
 # Beaglebone Black hardware SPI config:
 # DC = 'P9_15'


### PR DESCRIPTION
This change supports the orange pi.

This changes the demos to use board numbering so that the lcd can plug into the same connector on various boards.